### PR TITLE
specify AD and CD fields that should not be guessed/assumed

### DIFF
--- a/src/types/codeDefender.ts
+++ b/src/types/codeDefender.ts
@@ -5,13 +5,13 @@ export const CodeDefenderBaseInputSchema = z.object({
         .array(z.string())
         .min(1, 'At least one appId is required.')
         .describe(
-            '🆔 APPLICATION TARGETING: Array of application identifiers to monitor. 🎯 REQUIRED: Must provide at least one valid app ID. 💡 EXAMPLES: ["PX12345678"] for specific application analysis. 📊 SCOPE: Defines security monitoring boundaries.',
+            '🆔 APPLICATION TARGETING: Array of application identifiers to monitor. 🎯 REQUIRED: The user must provide at least one valid app ID. This value should not be guessed or assumed. 💡 EXAMPLES: ["PX12345678"] for specific application analysis. 📊 SCOPE: Defines security monitoring boundaries.',
         ),
     tld: z
         .array(z.string())
         .min(1, 'At least one top-level domain is required.')
         .describe(
-            '🌐 DOMAIN FILTERING: Array of top-level domains to analyze. 🎯 REQUIRED: Must specify target domains for security monitoring. 💡 EXAMPLES: ["example.com", "anotherexample.com"] for multi-domain analysis. 🔍 SCOPE: Controls domain-specific security assessment.',
+            '🌐 DOMAIN FILTERING: Array of top-level domains to analyze. 🎯 REQUIRED: The user must specify target domains for security monitoring. This value should not be guessed or assumed. 💡 EXAMPLES: ["example.com", "anotherexample.com"] for multi-domain analysis. 🔍 SCOPE: Controls domain-specific security assessment.',
         ),
     from: z
         .number()

--- a/src/types/cyberfraud/accountInfo.ts
+++ b/src/types/cyberfraud/accountInfo.ts
@@ -5,7 +5,7 @@ export const CyberfraudAccountInfoInputSchema = z.object({
         .string()
         .min(1, 'accountId is required')
         .describe(
-            '🔍 ACCOUNT LOOKUP: Unique account identifier for investigation and analysis. 🎯 REQUIRED: Must provide valid account ID from your system. ✅ RETURNS: Complete security profile if account exists, minimal response if not found. 💡 USE CASES: Incident response, fraud investigation, customer support, compliance auditing. 🚨 CRITICAL: Response structure depends entirely on account existence - use exists field to determine data availability.',
+            '🔍 ACCOUNT LOOKUP: Unique account identifier for investigation and analysis. 🎯 REQUIRED: The user must provide a valid account ID. This value should not be guessed or assumed. ✅ RETURNS: Complete security profile if account exists, minimal response if not found. 💡 USE CASES: Incident response, fraud investigation, customer support, compliance auditing. 🚨 CRITICAL: Response structure depends entirely on account existence - use exists field to determine data availability.',
         ),
     daysRange: z
         .number()


### PR DESCRIPTION
The difference between this:

![Screenshot 2025-06-19 at 10 46 22](https://github.com/user-attachments/assets/643d6140-5e38-4e9c-aafd-e03806c963bf)

And this:

![Screenshot 2025-06-19 at 10 49 30](https://github.com/user-attachments/assets/a0885185-2fa7-4170-8798-8f9640b03d32)