### PR TITLE
release: v1.0.1 with Docker marketplace support (#70)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -85,10 +85,12 @@ jobs:
 
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
           platforms: linux/amd64,linux/arm64
+          annotations: |
+            index:com.googleapis.cloudmarketplace.product.service.name=services/human-mcp-server
           tags: |
             us-docker.pkg.dev/hmn-registry/docker-public/human-mcp-server:${{ needs.extract_version.outputs.version }}
             us-docker.pkg.dev/hmn-registry/docker-public/human-mcp-server:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.1.0] - 2025-09-08
+## [1.0.1] - 2025-09-08
 
 ### Added
 
-* Release as Docker image
-* Graceful shutdown on SIGINT and SIGTERM
+* Docker container support with Google Cloud Marketplace compatibility
+* Graceful shutdown on SIGINT and SIGTERM signals
+* Multi-platform Docker images (linux/amd64, linux/arm64)
+* Required marketplace annotation for service identification
 
 ### Changed
 
-* Upgraded dependencies
+* Upgraded dependencies to latest versions
 
 ## [1.0.0] - 2025-07-22
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@humansecurity/human-mcp-server",
   "description": "Model Context Protocol (MCP) server providing comprehensive cybersecurity intelligence from HUMAN Security. Offers real-time attack monitoring, threat detection, fraud prevention, PCI DSS compliance validation, and supply chain security for AI-powered applications.",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./dist/index.cjs",
   "bin": "./dist/index.cjs",


### PR DESCRIPTION
* release: v1.0.1 with Docker marketplace support

- Upgrade docker/build-push-action from v4 to v6 for annotations support
- Add required Google Cloud Marketplace annotation to manifest index
- Update version from 1.1.0 to 1.0.1 for proper release sequence
- Include Docker container support with multi-platform builds
- Add graceful shutdown on SIGINT/SIGTERM signals

* Update CHANGELOG for version 1.0.1

Updated release date for version 1.0.1 and added Docker support.