### PR TITLE
Fix API token links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ If you only need one service, you can configure just that token:
 
 - **Documentation**: [HUMAN Security Documentation](https://docs.humansecurity.com)
 - **API Tokens**:
-  - [Cyberfraud](https://docs.humansecurity.com/applications-and-accounts/reference/api-authentication#getting-a-token-for-account-defender-bot-defender-or-credential-intelligence)
-  - [Code Defender](https://docs.humansecurity.com/applications-and-accounts/reference/api-authentication#getting-a-token-for-code-defender-or-pci-dss)
+  - [Cyberfraud](https://docs.humansecurity.com/applications/reference/authentication#getting-a-token-for-the-account-defender-adaptive-feedback-bot-defender-or-credential-intelligence-api)
+  - [Code Defender](https://docs.humansecurity.com/applications/reference/authentication#getting-a-token-for-the-code-defender-or-pci-dss-api)
 - **Technical Support**: Available through your HUMAN Security support channels
 
 ## 📄 License


### PR DESCRIPTION
Updated API token links for Cyberfraud and Code Defender in the support section.