### PR TITLE
bump version to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.5] - 2026-07-01
+
+### Changed
+
+* Adjusted traffic data tool to new backend routes
+
 ## [1.0.4] - 2025-09-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@humansecurity/human-mcp-server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@humansecurity/human-mcp-server",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@humansecurity/human-mcp-server",
   "description": "Model Context Protocol (MCP) server providing comprehensive cybersecurity intelligence from HUMAN Security. Offers real-time attack monitoring, threat detection, fraud prevention, PCI DSS compliance validation, and supply chain security for AI-powered applications.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "main": "./dist/index.cjs",
   "bin": "./dist/index.cjs",


### PR DESCRIPTION
Bump package version to 1.0.5 ahead of the `dev -> main` promotion.

- `package.json` and `package-lock.json` (root) 1.0.4 -> 1.0.5
- `CHANGELOG.md`: add 1.0.5 entry (traffic data tool adjusted to new backend routes)

Made with [Cursor](https://cursor.com)