### PR TITLE
Add Streamable HTTP transport mode for MCP clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+* HTTP (Streamable HTTP) transport mode via `MCP_TRANSPORT=http` environment variable, enabling clients with long per-call timeouts (e.g. Google ADK) to use the server without subprocess management.
+* `GET /health` endpoint returns `{"status":"ok"}` for container liveness probes.
+* `PORT`, `MCP_HTTP_HOST`, `MCP_HTTP_ALLOWED_HOSTS`, and `MCP_HTTP_ALLOWED_ORIGINS` env vars for HTTP transport configuration.
+* DNS-rebinding protection (`enableDnsRebindingProtection`) enabled by default in HTTP mode.
+* Per-request stateless isolation in HTTP mode — each `POST /mcp` gets a fresh `McpServer` instance so concurrent callers never share state.
+
 ## [1.2.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,6 +94,67 @@ To use Docker from your MCP client config (e.g., Cursor or Claude Desktop), repl
 }
 ```
 
+## 🌐 Running over HTTP (Streamable HTTP transport)
+
+By default the server communicates over **stdio** — the mode used by Claude Desktop, Cursor, and most MCP clients. An alternative **HTTP** transport is available for clients that need longer per-call timeouts (e.g. Google ADK, which caps stdio subprocesses at ~5 s) or that cannot manage a child process at all.
+
+### When to use HTTP vs. stdio
+
+| | stdio | HTTP |
+|---|---|---|
+| Claude Desktop / Cursor | ✅ default | not needed |
+| Google ADK / sre-ops-bot | ❌ 5 s timeout | ✅ use HTTP |
+| Kubernetes sidecar | possible | ✅ preferred |
+
+### Env vars
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MCP_TRANSPORT` | `stdio` | Set to `http` to enable HTTP mode; any other value exits with an error |
+| `PORT` | `8080` | HTTP listen port |
+| `MCP_HTTP_HOST` | `127.0.0.1` | Bind address. Use `0.0.0.0` for K8s pod liveness probes (see security note below) |
+| `MCP_HTTP_ALLOWED_HOSTS` | `127.0.0.1` | Comma-separated list of allowed `Host` header values (DNS-rebinding protection) |
+| `MCP_HTTP_ALLOWED_ORIGINS` | *(none)* | Comma-separated list of allowed `Origin` header values; omit for non-browser clients |
+
+### Security note
+
+HTTP mode has **no built-in authentication**. Use it only on a trusted network or as a sidecar running on localhost. If you set `MCP_HTTP_HOST=0.0.0.0` to allow Kubernetes httpGet liveness probes, set `MCP_HTTP_ALLOWED_HOSTS` to the pod's expected hostname to preserve DNS-rebinding protection.
+
+### Running with Docker (HTTP mode)
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HTTP_HOST=0.0.0.0 \
+  -e HUMAN_CYBERFRAUD_API_TOKEN=<value> \
+  -e HUMAN_CODE_DEFENDER_API_TOKEN=<value> \
+  us-docker.pkg.dev/hmn-registry-public/containers/human-mcp-server:latest
+```
+
+Verify it's up:
+
+```bash
+curl -s http://localhost:8080/health
+# {"status":"ok"}
+```
+
+### MCP client config (HTTP)
+
+```json
+{
+  "mcpServers": {
+    "human-security": {
+      "type": "http",
+      "url": "http://127.0.0.1:8080/mcp",
+      "env": {
+        "HUMAN_CYBERFRAUD_API_TOKEN": "your-cyberfraud-token",
+        "HUMAN_CODE_DEFENDER_API_TOKEN": "your-code-defender-token"
+      }
+    }
+  }
+}
+```
+
 ### Optional Configuration
 - **`HUMAN_API_HOST`**: Use a different API endpoint (default: `api.humansecurity.com`)
 - **`HUMAN_API_VERSION`**: Specify API version (default: `v1`)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,11 +1,175 @@
 import process from 'process';
+import http from 'node:http';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { StreamableHTTPServerTransportOptions } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { registerTools } from '../tools';
 import { HttpClient } from '../utils/httpClient';
 import { CyberfraudService } from '../services/cyberfraudService';
 import { CodeDefenderService } from '../services/codeDefenderService';
 import { MCP_VERSION } from '../utils/constants';
+
+type Services = {
+    cyberfraudService?: CyberfraudService;
+    codeDefenderService?: CodeDefenderService;
+};
+
+const BODY_SIZE_LIMIT = 1024 * 1024; // 1 MB
+
+async function readBody(req: http.IncomingMessage): Promise<{ body: string; tooLarge: boolean }> {
+    const chunks: Buffer[] = [];
+    let size = 0;
+
+    for await (const chunk of req) {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+        size += buf.length;
+        if (size > BODY_SIZE_LIMIT) {
+            return { body: '', tooLarge: true };
+        }
+        chunks.push(buf);
+    }
+
+    return { body: Buffer.concat(chunks).toString('utf8'), tooLarge: false };
+}
+
+function jsonRpcError(res: http.ServerResponse, statusCode: number, code: number, message: string): void {
+    res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', error: { code, message }, id: null }));
+}
+
+function startHttpServer(services: Services): http.Server {
+    const port = Number.parseInt(process.env.PORT ?? '8080', 10);
+    const host = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
+    const allowedHosts = process.env.MCP_HTTP_ALLOWED_HOSTS
+        ? process.env.MCP_HTTP_ALLOWED_HOSTS.split(',')
+              .map((h) => h.trim())
+              .filter(Boolean)
+        : ['127.0.0.1'];
+    const allowedOrigins = process.env.MCP_HTTP_ALLOWED_ORIGINS
+        ? process.env.MCP_HTTP_ALLOWED_ORIGINS.split(',')
+              .map((o) => o.trim())
+              .filter(Boolean)
+        : undefined;
+
+    if (host === '0.0.0.0' && !process.env.MCP_HTTP_ALLOWED_HOSTS) {
+        console.error(
+            'Warning: MCP_HTTP_HOST=0.0.0.0 but MCP_HTTP_ALLOWED_HOSTS is not set. ' +
+                'DNS rebinding protection is limited. Set MCP_HTTP_ALLOWED_HOSTS to the expected Host header value.',
+        );
+    }
+
+    const httpServer = http.createServer(async (req, res) => {
+        const url = req.url ?? '/';
+        const method = req.method ?? 'GET';
+
+        if (url === '/health') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'ok' }));
+            return;
+        }
+
+        if (url !== '/mcp') {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Not found' }));
+            return;
+        }
+
+        if (method === 'GET' || method === 'DELETE') {
+            jsonRpcError(res, 405, -32000, 'Method not allowed');
+            return;
+        }
+
+        if (method !== 'POST') {
+            jsonRpcError(res, 405, -32000, 'Method not allowed');
+            return;
+        }
+
+        // Quick pre-check via Content-Length before reading the body
+        const contentLength = req.headers['content-length'];
+        if (contentLength && Number.parseInt(contentLength, 10) > BODY_SIZE_LIMIT) {
+            jsonRpcError(res, 413, -32600, 'Request body too large');
+            return;
+        }
+
+        let body: string;
+        let tooLarge: boolean;
+        try {
+            ({ body, tooLarge } = await readBody(req));
+        } catch {
+            jsonRpcError(res, 500, -32603, 'Internal error reading request body');
+            return;
+        }
+
+        if (tooLarge) {
+            jsonRpcError(res, 413, -32600, 'Request body too large');
+            return;
+        }
+
+        let parsedBody: unknown;
+        try {
+            parsedBody = JSON.parse(body);
+        } catch {
+            jsonRpcError(res, 400, -32700, 'Parse error');
+            return;
+        }
+
+        // Fresh McpServer + transport per request — stateless isolation so concurrent callers never share state
+        const freshServer = new McpServer(
+            { name: 'HUMAN Security MCP Server', version: MCP_VERSION },
+            { capabilities: { tools: {} } },
+        );
+        registerTools(freshServer, services);
+
+        const transportOptions: StreamableHTTPServerTransportOptions = {
+            sessionIdGenerator: undefined,
+            enableDnsRebindingProtection: true,
+            allowedHosts,
+            allowedOrigins,
+        };
+        const transport = new StreamableHTTPServerTransport(transportOptions);
+
+        try {
+            await freshServer.connect(transport);
+            await transport.handleRequest(req, res, parsedBody);
+        } catch (err) {
+            console.error('Error handling MCP request:', err);
+            if (!res.headersSent) {
+                jsonRpcError(res, 500, -32603, 'Internal error');
+            }
+        } finally {
+            // Defer close until after the response is fully flushed so SSE streams are not truncated.
+            // The close frees SDK-allocated Maps/Sets/AjvJsonSchemaValidator (~2 KB/request).
+            res.once('finish', () => {
+                freshServer.close().catch((err) => console.error('Error closing MCP server instance:', err));
+            });
+        }
+    });
+
+    httpServer.listen(port, host, () => {
+        const addr = httpServer.address();
+        const actualPort = typeof addr === 'object' && addr ? addr.port : port;
+        // HTTP/1.1 Host headers include the port for non-default ports (e.g. "127.0.0.1:8080").
+        // Ensure both bare-host and host:port are accepted so fetch/curl requests pass validation.
+        const entriesToAdd = allowedHosts
+            .filter((h) => !h.includes(':'))
+            .map((h) => `${h}:${actualPort}`)
+            .filter((h) => !allowedHosts.includes(h));
+        allowedHosts.push(...entriesToAdd);
+        console.error(`MCP HTTP server listening on ${host}:${actualPort}`);
+    });
+
+    const shutdown = () => {
+        httpServer.close(() => {
+            console.error('MCP HTTP server shut down.');
+        });
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+
+    return httpServer;
+}
 
 export function createServer() {
     const server = new McpServer(
@@ -24,10 +188,7 @@ export function createServer() {
     const cyberfraudToken = process.env.HUMAN_CYBERFRAUD_API_TOKEN;
     const codeDefenderToken = process.env.HUMAN_CODE_DEFENDER_API_TOKEN;
 
-    const services: {
-        cyberfraudService?: CyberfraudService;
-        codeDefenderService?: CodeDefenderService;
-    } = {};
+    const services: Services = {};
 
     if (cyberfraudToken) {
         const cyberfraudHttpClient = new HttpClient(cyberfraudToken);
@@ -47,21 +208,48 @@ export function createServer() {
 
     registerTools(server, services);
 
+    let activeHttpServer: http.Server | undefined;
+
     return {
         start: () => {
-            const transport = new StdioServerTransport();
-            server.connect(transport).then(() => {
-                console.error('MCP server started...');
-            });
+            const mcpTransport = process.env.MCP_TRANSPORT ?? 'stdio';
 
-            const shutdown = () => {
-                server.close().then(() => {
-                    console.error('MCP server shut down.');
+            if (mcpTransport === 'http') {
+                activeHttpServer = startHttpServer(services);
+            } else if (mcpTransport === 'stdio') {
+                const transport = new StdioServerTransport();
+                server.connect(transport).then(() => {
+                    console.error('MCP server started...');
                 });
-            };
 
-            process.on('SIGINT', shutdown);
-            process.on('SIGTERM', shutdown);
+                const shutdown = () => {
+                    server.close().then(() => {
+                        console.error('MCP server shut down.');
+                    });
+                };
+
+                process.on('SIGINT', shutdown);
+                process.on('SIGTERM', shutdown);
+            } else {
+                console.error(`Unknown MCP_TRANSPORT value: "${mcpTransport}". Expected "stdio" or "http".`);
+                process.exit(1);
+            }
+        },
+
+        stop: (): Promise<void> =>
+            new Promise((resolve) => {
+                if (activeHttpServer) {
+                    activeHttpServer.close(() => resolve());
+                    activeHttpServer.closeAllConnections();
+                    activeHttpServer = undefined;
+                } else {
+                    resolve();
+                }
+            }),
+
+        getPort: (): number | undefined => {
+            const addr = activeHttpServer?.address();
+            return typeof addr === 'object' && addr ? addr.port : undefined;
         },
     };
 }

--- a/test/server/httpTransport.test.ts
+++ b/test/server/httpTransport.test.ts
@@ -1,0 +1,370 @@
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import http from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createServer } from '../../src/server';
+import { CyberfraudService } from '../../src/services/cyberfraudService';
+
+const { expect } = chai;
+chai.use(chaiAsPromised);
+
+const MCP_ACCEPT = 'application/json, text/event-stream';
+
+const MCP_INIT_REQUEST = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '0.0.1' },
+    },
+};
+
+// The SDK responds with SSE format: lines beginning with "data:" contain the JSON payload.
+// This helper normalises both SSE and plain JSON responses.
+async function parseMcpResponse(res: Response): Promise<{ status: number; json: unknown }> {
+    const text = await res.text();
+    let json: unknown;
+    const dataLine = text.split('\n').find((line) => line.startsWith('data:'));
+    if (dataLine) {
+        json = JSON.parse(dataLine.slice('data:'.length).trim());
+    } else {
+        json = JSON.parse(text);
+    }
+    return { status: res.status, json };
+}
+
+async function postMcp(port: number, body: unknown): Promise<{ status: number; json: unknown }> {
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: MCP_ACCEPT },
+        body: JSON.stringify(body),
+    });
+    return parseMcpResponse(res);
+}
+
+async function getUrl(url: string): Promise<{ status: number; json: unknown }> {
+    const res = await fetch(url);
+    const json = await res.json();
+    return { status: res.status, json };
+}
+
+async function requestMcp(port: number, method: string): Promise<{ status: number; json: unknown }> {
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method,
+        headers: { Accept: MCP_ACCEPT },
+    });
+    const text = await res.text();
+    let json: unknown;
+    try {
+        json = JSON.parse(text);
+    } catch {
+        json = text;
+    }
+    return { status: res.status, json };
+}
+
+function waitForPort(server: ReturnType<typeof createServer>): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const deadline = setTimeout(() => reject(new Error('Server did not start in time')), 2000);
+        const poll = setInterval(() => {
+            const p = server.getPort();
+            if (p !== undefined) {
+                clearInterval(poll);
+                clearTimeout(deadline);
+                resolve(p);
+            }
+        }, 10);
+    });
+}
+
+describe('HTTP transport', () => {
+    let server: ReturnType<typeof createServer>;
+    let port: number;
+
+    before(async () => {
+        sinon.stub(console, 'error');
+        sinon.stub(process, 'env').value({
+            MCP_TRANSPORT: 'http',
+            PORT: '0',
+            MCP_HTTP_HOST: '127.0.0.1',
+            HUMAN_CYBERFRAUD_API_TOKEN: 'test-cf-token',
+            HUMAN_CODE_DEFENDER_API_TOKEN: 'test-cd-token',
+        });
+        server = createServer();
+        server.start();
+        port = await waitForPort(server);
+    });
+
+    after(async () => {
+        await server.stop();
+        sinon.restore();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('GET /health returns 200 { status: "ok" }', async () => {
+        const { status, json } = await getUrl(`http://127.0.0.1:${port}/health`);
+        expect(status).to.equal(200);
+        expect(json).to.deep.equal({ status: 'ok' });
+    });
+
+    it('POST /mcp with initialize returns a valid MCP response', async () => {
+        const { status, json } = await postMcp(port, MCP_INIT_REQUEST);
+        expect(status).to.be.oneOf([200, 202]);
+        const response = json as Record<string, unknown>;
+        expect(response).to.have.property('jsonrpc', '2.0');
+        expect(response).to.have.property('id', 1);
+        expect(response).to.have.property('result');
+        const result = response.result as Record<string, unknown>;
+        expect(result).to.have.property('serverInfo');
+        const serverInfo = result.serverInfo as Record<string, unknown>;
+        expect(serverInfo).to.have.property('name', 'HUMAN Security MCP Server');
+    });
+
+    it('POST /mcp tools/call returns a JSON-RPC response (not a crash)', async () => {
+        sinon.stub(CyberfraudService.prototype, 'getAccountInfo').resolves({
+            applicationName: 'test-app',
+        } as never);
+
+        const { status, json } = await postMcp(port, {
+            jsonrpc: '2.0',
+            id: 3,
+            method: 'tools/call',
+            params: { name: 'human_get_account_info', arguments: {} },
+        });
+        // Accepts 200/202 (success) or 400 (SDK rejects uninitialized call) — either way, no crash
+        expect(status).to.be.oneOf([200, 202, 400]);
+        const response = json as Record<string, unknown>;
+        expect(response).to.have.property('jsonrpc', '2.0');
+    });
+
+    it('GET /mcp returns 405 with JSON-RPC error shape', async () => {
+        const { status, json } = await requestMcp(port, 'GET');
+        expect(status).to.equal(405);
+        const response = json as Record<string, unknown>;
+        expect(response).to.have.property('jsonrpc', '2.0');
+        expect(response).to.have.property('error');
+        const error = response.error as Record<string, unknown>;
+        expect(error).to.have.property('code');
+        expect(error).to.have.property('message');
+        expect(response).to.have.property('id', null);
+    });
+
+    it('DELETE /mcp returns 405 with JSON-RPC error shape', async () => {
+        const { status, json } = await requestMcp(port, 'DELETE');
+        expect(status).to.equal(405);
+        const response = json as Record<string, unknown>;
+        expect(response).to.have.property('jsonrpc', '2.0');
+        expect(response).to.have.property('error');
+        expect(response).to.have.property('id', null);
+    });
+
+    it('POST /mcp with malformed JSON returns 400 with JSON-RPC error', async () => {
+        const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: MCP_ACCEPT },
+            body: '{ invalid json',
+        });
+        expect(res.status).to.equal(400);
+        const json = (await res.json()) as Record<string, unknown>;
+        expect(json).to.have.property('jsonrpc', '2.0');
+        expect(json).to.have.property('error');
+        expect(json).to.have.property('id', null);
+    });
+
+    it('two concurrent POST /mcp initialize requests return independent responses', async () => {
+        const [a, b] = await Promise.all([
+            postMcp(port, { ...MCP_INIT_REQUEST, id: 10 }),
+            postMcp(port, { ...MCP_INIT_REQUEST, id: 11 }),
+        ]);
+
+        const ra = a.json as Record<string, unknown>;
+        const rb = b.json as Record<string, unknown>;
+
+        expect(ra).to.have.property('id', 10);
+        expect(rb).to.have.property('id', 11);
+        expect(ra).to.have.property('result');
+        expect(rb).to.have.property('result');
+    });
+
+    it('GET /unknown-path returns 404', async () => {
+        const res = await fetch(`http://127.0.0.1:${port}/not-a-real-path`);
+        expect(res.status).to.equal(404);
+    });
+
+    it('POST /mcp with Content-Length exceeding 1 MB returns 413', (done) => {
+        // fetch validates Content-Length matches body size, so use http.request directly
+        const req = http.request(
+            {
+                host: '127.0.0.1',
+                port,
+                path: '/mcp',
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: MCP_ACCEPT,
+                    'Content-Length': String(2 * 1024 * 1024),
+                },
+            },
+            (res) => {
+                expect(res.statusCode).to.equal(413);
+                let body = '';
+                res.on('data', (chunk: string) => {
+                    body += chunk;
+                });
+                res.on('end', () => {
+                    const json = JSON.parse(body) as Record<string, unknown>;
+                    expect(json).to.have.property('jsonrpc', '2.0');
+                    expect(json).to.have.property('error');
+                    done();
+                });
+            },
+        );
+        req.on('error', done);
+        req.write('{}');
+        req.end();
+    });
+
+    it('POST /mcp with actual body exceeding 1 MB returns 413', async () => {
+        const bigBody = JSON.stringify({ data: 'x'.repeat(2 * 1024 * 1024) });
+        const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: MCP_ACCEPT },
+            body: bigBody,
+        });
+        expect(res.status).to.equal(413);
+    });
+
+    it('PUT /mcp returns 405 with JSON-RPC error shape', async () => {
+        const { status, json } = await requestMcp(port, 'PUT');
+        expect(status).to.equal(405);
+        const response = json as Record<string, unknown>;
+        expect(response).to.have.property('jsonrpc', '2.0');
+        expect(response).to.have.property('error');
+        expect(response).to.have.property('id', null);
+    });
+
+    it('concurrent requests do not bleed state across 5 rounds', async function () {
+        this.timeout(10000);
+        for (let i = 0; i < 5; i++) {
+            const [a, b] = await Promise.all([
+                postMcp(port, { ...MCP_INIT_REQUEST, id: 100 + i }),
+                postMcp(port, { ...MCP_INIT_REQUEST, id: 200 + i }),
+            ]);
+            const ra = a.json as Record<string, unknown>;
+            const rb = b.json as Record<string, unknown>;
+            expect(ra).to.have.property('id', 100 + i);
+            expect(rb).to.have.property('id', 200 + i);
+        }
+    });
+
+    it('freshServer.close() is called after each request to prevent memory leak', async () => {
+        const closeSpy = sinon.spy(McpServer.prototype, 'close');
+        await postMcp(port, MCP_INIT_REQUEST);
+        expect(closeSpy.callCount).to.be.at.least(1);
+        closeSpy.restore();
+    });
+});
+
+describe('HTTP transport — invalid MCP_TRANSPORT', () => {
+    it('calls process.exit(1) when MCP_TRANSPORT is an unknown value', () => {
+        const exitStub = sinon.stub(process, 'exit');
+        sinon.stub(console, 'error');
+        sinon.stub(process, 'env').value({ MCP_TRANSPORT: 'invalid-transport' });
+
+        const s = createServer();
+        s.start();
+
+        expect(exitStub.calledOnceWith(1)).to.be.true;
+        sinon.restore();
+    });
+});
+
+describe('HTTP transport — allowedHosts port-suffix', () => {
+    let altServer: ReturnType<typeof createServer>;
+    let altPort: number;
+
+    before(async () => {
+        sinon.stub(console, 'error');
+        sinon.stub(process, 'env').value({
+            MCP_TRANSPORT: 'http',
+            PORT: '0',
+            MCP_HTTP_HOST: '127.0.0.1',
+            MCP_HTTP_ALLOWED_HOSTS: 'myapp.internal',
+        });
+        altServer = createServer();
+        altServer.start();
+        altPort = await waitForPort(altServer);
+    });
+
+    after(async () => {
+        await altServer.stop();
+        sinon.restore();
+    });
+
+    it('accepts POST /mcp when Host header includes port suffix for a user-specified allowed host', (done) => {
+        // fetch cannot override the Host header (Fetch spec forbids it); use http.request directly
+        const body = JSON.stringify(MCP_INIT_REQUEST);
+        const req = http.request(
+            {
+                host: '127.0.0.1',
+                port: altPort,
+                path: '/mcp',
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: MCP_ACCEPT,
+                    Host: `myapp.internal:${altPort}`,
+                    'Content-Length': Buffer.byteLength(body),
+                },
+            },
+            (res) => {
+                // SDK's DNS-rebinding check returns 403 when Host is not in allowedHosts
+                expect(res.statusCode).to.not.equal(403);
+                res.resume(); // drain to allow connection reuse
+                done();
+            },
+        );
+        req.on('error', done);
+        req.write(body);
+        req.end();
+    });
+});
+
+describe('stdio transport', () => {
+    afterEach(() => sinon.restore());
+
+    it('connects McpServer with StdioServerTransport when MCP_TRANSPORT is stdio', () => {
+        sinon.stub(console, 'error');
+        sinon.stub(process, 'env').value({ MCP_TRANSPORT: 'stdio' });
+        const connectStub = sinon.stub(McpServer.prototype, 'connect').resolves();
+        createServer().start();
+        expect(connectStub.called).to.be.true;
+        expect(connectStub.firstCall.args[0]).to.be.instanceOf(StdioServerTransport);
+    });
+
+    it('connects McpServer with StdioServerTransport when MCP_TRANSPORT is not set', () => {
+        sinon.stub(console, 'error');
+        sinon.stub(process, 'env').value({});
+        const connectStub = sinon.stub(McpServer.prototype, 'connect').resolves();
+        createServer().start();
+        expect(connectStub.called).to.be.true;
+        expect(connectStub.firstCall.args[0]).to.be.instanceOf(StdioServerTransport);
+    });
+
+    it('getPort() returns undefined when HTTP server has not been started', async () => {
+        sinon.stub(console, 'error');
+        sinon.stub(process, 'env').value({ MCP_TRANSPORT: 'stdio' });
+        sinon.stub(McpServer.prototype, 'connect').resolves();
+        const s = createServer();
+        s.start();
+        expect(s.getPort()).to.be.undefined;
+        await s.stop(); // covers stop() else branch (no active HTTP server)
+    });
+});


### PR DESCRIPTION
## Summary
- Add `MCP_TRANSPORT=http` Streamable HTTP transport for clients with long timeouts or no subprocess support
- Add `GET /health`, DNS rebinding protection, per-request stateless isolation, and request body limits
- Document HTTP mode in README and CHANGELOG

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`
